### PR TITLE
Support Inferno v8 with brunch 4

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
     "presets": [
-        "env"
+      "@babel/preset-env"
     ],
     "plugins": [
         "inferno"

--- a/package.json
+++ b/package.json
@@ -12,18 +12,20 @@
     "prod": "brunch build --production"
   },
   "dependencies": {
-    "inferno": "^5.0.2"
+    "inferno": "^v8.0.0-alpha.3"
   },
   "devDependencies": {
-    "auto-reload-brunch": "^2.7.1",
-    "babel-brunch": "^6.1.1",
-    "babel-plugin-inferno": "^5.0.1",
-    "babel-plugin-syntax-jsx": "^6.18.0",
-    "babel-preset-env": "^1.5.2",
-    "brunch": "^2.10.9",
-    "clean-css-brunch": "^2.10.0",
-    "css-brunch": "^2.10.0",
-    "javascript-brunch": "^2.10.0",
-    "uglify-js-brunch": "^2.10.0"
+    "@babel/plugin-syntax-jsx": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
+    "@babel/register": "^7.14.5",
+    "@babel/runtime": "^7.13.17",
+    "auto-reload-brunch": "^3",
+    "babel-brunch": "^7",
+    "babel-plugin-inferno": "^6.3.0",
+    "brunch": "^4",
+    "clean-css-brunch": "^3",
+    "css-brunch": "^2",
+    "uglify-js-brunch": "^2",
+    "javascript-brunch": "^2"
   }
 }


### PR DESCRIPTION
The current version of the brunch skeleton uses Inferno 5 and brunch 2. It is non-trivial for a beginner to upgrade to Inferno v8 so I think this should be updated since it is referenced in the official docs.

Also, Brunch is a great way to get started with Inferno for simple projects where Create Inferno App might be a bit daunting.

This PR bumps inferno to v8-alpha.3 and brunch 4.

